### PR TITLE
Don't try to tidy directories

### DIFF
--- a/lib/Code/TidyAll/Git/Precommit.pm
+++ b/lib/Code/TidyAll/Git/Precommit.pm
@@ -50,7 +50,7 @@ sub check {
             mode       => 'commit',
             %{ $self->tidyall_options },
         );
-        my @results = $tidyall->process_files( map { "$root_dir/$_" } @files );
+        my @results = $tidyall->process_files( grep { ! -d $_ } map { "$root_dir/$_" } @files );
 
         if ( my @error_results = grep { $_->error } @results ) {
             my $error_count = scalar(@error_results);


### PR DESCRIPTION
Usually git status only lists files, but there is one exception:
submodules. When you use submodules and we are committing a new
version for a particular submodule, you'll get the submodule directory
in the git status output.
