### PR TITLE
Quiet test output and put diag() after ok() call

### DIFF
--- a/lib/Test/Code/TidyAll.pm
+++ b/lib/Test/Code/TidyAll.pm
@@ -20,7 +20,13 @@ sub tidyall_ok {
         $conf_file = Code::TidyAll->find_conf_file( \@conf_names, "." );
     }
     my $ct =
-      Code::TidyAll->new_from_conf_file( $conf_file, check_only => 1, mode => 'test', %options );
+    Code::TidyAll->new_from_conf_file(
+        $conf_file,
+        quiet      => 1,
+        check_only => 1,
+        mode       => 'test',
+        %options,
+    );
     my @files = $ct->find_matched_files;
     $test->plan( tests => scalar(@files) );
     foreach my $file (@files) {


### PR DESCRIPTION
This shuts up Code::TidyAll when used from Test::Code::TidyAll. I also moved the diag() call to after the ok() call. This makes our internal tools happy, and I think it just makes more sense ("test failed, here's the error").
