### PR TITLE
avoid being tripped up by git status weirdness

### DIFF
--- a/lib/Code/TidyAll/Git/Util.pm
+++ b/lib/Code/TidyAll/Git/Util.pm
@@ -11,13 +11,53 @@ our $VERSION = '0.30';
 
 our @EXPORT_OK = qw(git_uncommitted_files);
 
+sub _relevant_files_from_status {
+    my ($porcelain) = @_;
+
+    my ($comment, $rest) = split /\0/, $porcelain, 2;
+
+    my @files;
+
+    {
+      local $_ = $rest;
+
+      # There can't possibly be more records than nuls plus one, so we use this
+      # as an upper bound on passes.
+      my $times = tr/\0/\0/;
+
+      for my $i (0 .. $times) {
+        last if /\G\Z/gc;
+
+        /\G(..) /g;
+        my $mode = $1;
+
+        /\G([^\0]+)\0/g;
+        my $name = $1;
+
+        # on renames, parse but throw away the "renamed from" filename
+        if ($mode =~ /R/) {
+          /\G([^\0]+)\0/g;
+        }
+
+        # deletions and renames don't cause tidying
+        next unless $mode =~ /[MAC]/;
+
+        push @files, $name;
+      }
+    }
+
+    return @files;
+}
+
 sub git_uncommitted_files {
     my ($dir) = @_;
 
     $dir = realpath($dir);
     my $pushd  = pushd($dir);
-    my $output = capturex( "git", "status", "--porcelain" );
-    my @files  = ( $output =~ /^..\s(.*?)(?: -> .*)?$/g );
+    my $output = capturex( "git", "status", "--porcelain", "-z" );
+
+    my @files = _relevant_files_from_status($output);
+
     @files = uniq( map {"$dir/$_"} @files );
     return @files;
 }

--- a/lib/Code/TidyAll/Git/Util.pm
+++ b/lib/Code/TidyAll/Git/Util.pm
@@ -16,8 +16,8 @@ sub git_uncommitted_files {
 
     $dir = realpath($dir);
     my $pushd  = pushd($dir);
-    my $output = capturex( "git", "status" );
-    my @files  = ( $output =~ /(?:new file|modified):\s+(.*)/g );
+    my $output = capturex( "git", "status", "--porcelain" );
+    my @files  = ( $output =~ /^..\s(.*?)(?: -> .*)?$/g );
     @files = uniq( map {"$dir/$_"} @files );
     return @files;
 }

--- a/t/lib/Test/Code/TidyAll/Basic.pm
+++ b/t/lib/Test/Code/TidyAll/Basic.pm
@@ -433,6 +433,28 @@ sub test_errors : Tests {
     throws_ok { $ct->process_paths("$other_dir/foo.txt") } qr/not underneath root dir/;
 }
 
+sub test_git_files : Tests {
+    my $self = shift;
+
+    # Included examples:
+    # * basic modified file
+    # * renamed but not modified file (perltidy) -- the -> is in the filename
+    # * deleted file
+    # * renamed and modified file
+    my $status = qq{## git-status-porcelain\0 M lib/Code/TidyAll/Git/Util.pm\0R  perltidyrc -> xyz\0perltidyrc\0 M t/lib/Test/Code/TidyAll/Basic.pm\0D  tidyall.ini\0RM weaver.initial\0weaver.ini\0};
+
+    require Code::TidyAll::Git::Util;
+    my @files = Code::TidyAll::Git::Util::_relevant_files_from_status($status);
+    is_deeply(
+      \@files,
+      [
+        "lib/Code/TidyAll/Git/Util.pm",
+        "t/lib/Test/Code/TidyAll/Basic.pm",
+        "weaver.initial",
+      ]
+    );
+}
+
 sub test_cli : Tests {
     my $self = shift;
     my $output;


### PR DESCRIPTION
it might have color (if color.status is always/yes), or change format in
future git, etc.

stick to --porcelain, which is guaranteed not to change

this probably paves the way for fixing #38, but I didn't attempt it