### PR TITLE
Option to leave the test dir behind if asked to

### DIFF
--- a/.ispell_english
+++ b/.ispell_english
@@ -52,6 +52,7 @@ repos
 ro
 runtime
 rw
+shebang
 sourceforge
 svn
 tidiers

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Added a --no-cleanup option for the tidyall script that causes it to leave
+  any tempdirs it creates behind. Implemented by Mark Fowler. GitHub #41.
+
+
 0.29     2015-08-15
 
 - Replaced use of Digest::SHA1 with Digest::SHA. The latter module has been

--- a/bin/tidyall
+++ b/bin/tidyall
@@ -34,6 +34,7 @@ Options:
    --iterations <count>     Number of times to repeat each transform - default is 1
    --no-backups             Don\'t backup files before processing
    --no-cache               Don\'t cache last processed times
+   --no-cleanup             Don\'t cleanup the temporary files
    --output-suffix <suffix> Suffix to add to tidied file
    --refresh-cache          Erase any existing cache info before processing each file
    --root-dir               Specify root directory explicitly
@@ -66,6 +67,7 @@ GetOptions(
     'data-dir=s'      => \$params{data_dir},
     'no-backups'      => \$params{no_backups},
     'no-cache'        => \$params{no_cache},
+    'no-cleanup'      => \$params{no_cleanup},
     'output-suffix=s' => \$params{output_suffix},
     'refresh-cache'   => \$params{refresh_cache},
     'root-dir=s'      => \$params{root_dir},

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -50,6 +50,8 @@ has 'base_sig'         => ( is => 'lazy', init_arg => undef );
 has 'plugin_objects'   => ( is => 'lazy', init_arg => undef );
 has 'plugins_for_mode' => ( is => 'lazy', init_arg => undef );
 
+with 'Code::TidyAll::Role::Tempdir';
+
 sub _build_backup_dir {
     my $self = shift;
     return $self->data_dir . "/backups";
@@ -490,12 +492,6 @@ sub _sig {
     return sha1_hex( join( ",", @$data ) );
 }
 
-sub _tempdir {
-    my ($self) = @_;
-    $self->{tempdir} ||= tempdir_simple();
-    return $self->{tempdir};
-}
-
 sub msg {
     my ( $self, $format, @params ) = @_;
     $self->msg_outputter()->( $format, @params );
@@ -606,6 +602,11 @@ by default.
 =item backup_ttl
 
 =item check_only
+
+=item no_cleanup
+
+A boolean indicating if we should skip cleaning temporary files or
+not. Defaults to false.
 
 =item data_dir
 

--- a/lib/Code/TidyAll/Role/Tempdir.pm
+++ b/lib/Code/TidyAll/Role/Tempdir.pm
@@ -1,0 +1,59 @@
+package Code::TidyAll::Role::Tempdir;
+
+use Moo::Role;
+
+use Cwd qw(realpath);
+use File::Temp qw(tempdir);
+
+our $VERSION = '0.30';
+
+has '_tempdir'   => ( is => 'ro', lazy => 1, builder => 1 );
+has 'no_cleanup' => ( is => 'ro', default => 0 );
+
+sub _build__tempdir {
+    my ($self) = @_;
+    return realpath(
+        tempdir(
+            'Code-TidyAll-XXXX',
+            TMPDIR  => 1,
+            CLEANUP => !$self->no_cleanup,
+        )
+    );
+}
+
+1;
+
+# ABSTRACT: Provides a _tempdir attribute for Code::TidyAll classes
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 SYNOPSIS
+
+    package Whatever;
+    use Moo;
+    with 'Code::TidyAll::Role::Tempdir';
+
+=head1 DESCRIPTION
+
+A role to add tempdir attributes to classes.
+
+=head1 ATTRIBUTES
+
+=over
+
+=item _tempdir
+
+The temp directory. Lazily constructed if not passed
+
+=item no_cleanup
+
+A boolean indicating if the temp directory created by the C<_tempdir> builder
+should not automatically clean up after itself
+
+=back
+
+=cut


### PR DESCRIPTION
A Podweaver checker we use, which weaves the pod then checks it with pod checker, was reporting an error, but without the temp file (which was deleted on exit) we couldn't work out what the error was referring to.

Thus, I added a command line option to leave the temp dir behind.  This required refactoring the code to create temp dirs out of Code::TidyAll::Util into a role, but I left the old code behind (as it's a public interface that in theory any number of plugins could be relying on)