### PR TITLE
Manual Plugin Ordering

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@
   file. This is helpful if you want to know why a file isn't being ignored,
   for example.
 
+- Added a new plugin configuration option for the rc file, "weight". You can
+  use this to exercise greater control over the order that plugins run in.
+
 
 0.31     2015-11-17
 

--- a/bin/tidyall
+++ b/bin/tidyall
@@ -462,9 +462,8 @@ arguments to pass to the underlying command-line utility.
 
 =item weight
 
-This is an integer that is used to sort plugins. By default, tidier
-plugins run first, then validator plugins, with each group sorted
-alphabetically.
+This is an integer that is used to sort plugins. By default, tidier plugins run
+first, then validator plugins, with each group sorted alphabetically.
 
 =back
 
@@ -474,9 +473,9 @@ If multiple plugins match a file, tidiers are applied before validators so that
 validators are checking the final result. Within those two groups, the plugins
 are applied in alphabetical order by plugin name/description.
 
-You can also explicitly set the weight of each plugin. By default, tidiers
-have a weight of 50 and validators have a weight of 60. You can set the weight
-to any integer to influence when the plugin runs.
+You can also explicitly set the weight of each plugin. By default, tidiers have
+a weight of 50 and validators have a weight of 60. You can set the weight to
+any integer to influence when the plugin runs.
 
 The application of multiple plugins is all-or-nothing. If an error occurs
 during the application of any plugin, the file is not modified at all.

--- a/bin/tidyall
+++ b/bin/tidyall
@@ -460,6 +460,12 @@ L<perlcritic|Code::TidyAll::Plugin::PerlCritic> and
 L<podtidy|Code::TidyAll::Plugin::PodTidy>) take this option, which specifies
 arguments to pass to the underlying command-line utility.
 
+=item weight
+
+This is an integer that is used to sort plugins. By default, tidier
+plugins run first, then validator plugins, with each group sorted
+alphabetically.
+
 =back
 
 =head1 PLUGIN ORDER AND ATOMICITY
@@ -467,6 +473,10 @@ arguments to pass to the underlying command-line utility.
 If multiple plugins match a file, tidiers are applied before validators so that
 validators are checking the final result. Within those two groups, the plugins
 are applied in alphabetical order by plugin name/description.
+
+You can also explicitly set the weight of each plugin. By default, tidiers
+have a weight of 50 and validators have a weight of 60. You can set the weight
+to any integer to influence when the plugin runs.
 
 The application of multiple plugins is all-or-nothing. If an error occurs
 during the application of any plugin, the file is not modified at all.

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -95,16 +95,11 @@ sub _build_plugin_objects {
     my @plugin_objects = map { $self->_load_plugin( $_, $self->plugins->{$_} ) }
         keys( %{ $self->plugins_for_mode } );
 
-    # Sort tidiers before validators, then by weight, then alphabetical
+    # Sort tidiers by weight (by default validators have a weight of 60 and non-
+    # validators a weight of 50 meaning non-validators normally go first), then
+    # alphabetical
     # TODO: These should probably sort in a consistent way independent of locale
-    #
-    return [
-        sort {
-                   ( $a->is_validator <=> $b->is_validator )
-                || ( $a->weight <=> $b->weight )
-                || ( $a->name cmp $b->name )
-        } @plugin_objects
-    ];
+    return [ sort { ( $a->weight <=> $b->weight ) || ( $a->name cmp $b->name ) } @plugin_objects ];
 }
 
 sub BUILD {

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -95,10 +95,16 @@ sub _build_plugin_objects {
     my @plugin_objects = map { $self->_load_plugin( $_, $self->plugins->{$_} ) }
         keys( %{ $self->plugins_for_mode } );
 
-    # Sort tidiers before validators, then alphabetical
+    # Sort tidiers before validators, then by ordering, then alphabetical
+    # TODO: These should probably sort in a consistent way independent of locale
     #
-    return [ sort { ( $a->is_validator <=> $b->is_validator ) || ( $a->name cmp $b->name ) }
-            @plugin_objects ];
+    return [
+        sort {
+                   ( $a->is_validator <=> $b->is_validator )
+                || ( $a->ordering <=> $b->ordering )
+                || ( $a->name cmp $b->name )
+        } @plugin_objects
+    ];
 }
 
 sub BUILD {
@@ -614,8 +620,8 @@ by default.
 
 =item no_cleanup
 
-A boolean indicating if we should skip cleaning temporary files or
-not. Defaults to false.
+A boolean indicating if we should skip cleaning temporary files or not.
+Defaults to false.
 
 =item data_dir
 

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -95,13 +95,13 @@ sub _build_plugin_objects {
     my @plugin_objects = map { $self->_load_plugin( $_, $self->plugins->{$_} ) }
         keys( %{ $self->plugins_for_mode } );
 
-    # Sort tidiers before validators, then by ordering, then alphabetical
+    # Sort tidiers before validators, then by weight, then alphabetical
     # TODO: These should probably sort in a consistent way independent of locale
     #
     return [
         sort {
                    ( $a->is_validator <=> $b->is_validator )
-                || ( $a->ordering <=> $b->ordering )
+                || ( $a->weight <=> $b->weight )
                 || ( $a->name cmp $b->name )
         } @plugin_objects
     ];

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -296,7 +296,7 @@ sub process_source {
     my $new_contents = my $orig_contents = $contents;
     my $plugin;
 
-    if ($self->verbose) {
+    if ( $self->verbose ) {
         $self->msg("[applying the following plugins: @plugins]");
     }
 

--- a/lib/Code/TidyAll/Plugin.pm
+++ b/lib/Code/TidyAll/Plugin.pm
@@ -16,10 +16,10 @@ has 'ignore'       => ( is => 'ro' );
 has 'is_tidier'    => ( is => 'lazy' );
 has 'is_validator' => ( is => 'lazy' );
 has 'name'         => ( is => 'ro', required => 1 );
-has 'ordering'     => ( is => 'lazy' );
 has 'select'       => ( is => 'ro' );
 has 'shebang'      => ( is => 'ro' );
 has 'tidyall'      => ( is => 'ro', required => 1, weak_ref => 1 );
+has 'weight'       => ( is => 'lazy' );
 
 # Internal
 has 'ignore_regex' => ( is => 'lazy' );
@@ -62,8 +62,8 @@ sub _build_is_validator {
     return ( $self->can('validate_source') || $self->can('validate_file') ) ? 1 : 0;
 }
 
-# default orderings
-sub _build_ordering { return 50; }
+# default weight
+sub _build_weight { return 50; }
 
 sub BUILD {
     my ( $self, $params ) = @_;
@@ -235,15 +235,15 @@ A standard attribute for specifying the name of the command to run, e.g.
 
 Name of the plugin to be used in error messages etc.
 
-=item ordering
+=item weight
 
-A number indicating the relative ordering of the plugin's execution relative to
-other plugins of the same type.  The lower the number the sooner the plugin
+A number indicating the relative weight of the plugin, used to calculate the
+order the plugins will execute in.  The lower the number the sooner the plugin
 will be executed.
 
 The order of plugin execution is determined first by the plugin type (tidiers
-are executed before validators), then by the value of the C<ordering> attribute,
-and then (if multiple plugins have the same ordering>) finally by sorting by the
+are executed before validators), then by the value of the C<weight> attribute,
+and then (if multiple plugins have the same weight>) finally by sorting by the
 name of module.
 
 =item tidyall

--- a/lib/Code/TidyAll/Plugin.pm
+++ b/lib/Code/TidyAll/Plugin.pm
@@ -16,6 +16,7 @@ has 'ignore'       => ( is => 'ro' );
 has 'is_tidier'    => ( is => 'lazy' );
 has 'is_validator' => ( is => 'lazy' );
 has 'name'         => ( is => 'ro', required => 1 );
+has 'ordering'     => ( is => 'lazy' );
 has 'select'       => ( is => 'ro' );
 has 'shebang'      => ( is => 'ro' );
 has 'tidyall'      => ( is => 'ro', required => 1, weak_ref => 1 );
@@ -60,6 +61,9 @@ sub _build_is_validator {
     my ($self) = @_;
     return ( $self->can('validate_source') || $self->can('validate_file') ) ? 1 : 0;
 }
+
+# default orderings
+sub _build_ordering { return 50; }
 
 sub BUILD {
     my ( $self, $params ) = @_;
@@ -230,6 +234,17 @@ A standard attribute for specifying the name of the command to run, e.g.
 =item name
 
 Name of the plugin to be used in error messages etc.
+
+=item ordering
+
+A number indicating the relative ordering of the plugin's execution relative to
+other plugins of the same type.  The lower the number the sooner the plugin
+will be executed.
+
+The order of plugin execution is determined first by the plugin type (tidiers
+are executed before validators), then by the value of the C<ordering> attribute,
+and then (if multiple plugins have the same ordering>) finally by sorting by the
+name of module.
 
 =item tidyall
 

--- a/lib/Code/TidyAll/Plugin.pm
+++ b/lib/Code/TidyAll/Plugin.pm
@@ -63,7 +63,11 @@ sub _build_is_validator {
 }
 
 # default weight
-sub _build_weight { return 50; }
+sub _build_weight {
+    my ($self) = @_;
+    return 60 if $self->is_validator;
+    return 50;
+}
 
 sub BUILD {
     my ( $self, $params ) = @_;
@@ -231,20 +235,15 @@ A standard attribute for passing command line arguments.
 A standard attribute for specifying the name of the command to run, e.g.
 "/usr/local/bin/perlcritic".
 
+=item is_validator
+
+An attribute that indicates if this is a validator or not; By default this
+returns true if either C<validate_source> or C<validate_file> methods have been
+implemented.
+
 =item name
 
 Name of the plugin to be used in error messages etc.
-
-=item weight
-
-A number indicating the relative weight of the plugin, used to calculate the
-order the plugins will execute in.  The lower the number the sooner the plugin
-will be executed.
-
-The order of plugin execution is determined first by the plugin type (tidiers
-are executed before validators), then by the value of the C<weight> attribute,
-and then (if multiple plugins have the same weight>) finally by sorting by the
-name of module.
 
 =item tidyall
 
@@ -253,6 +252,20 @@ A weak reference back to the L<Code::TidyAll> object.
 =item select, ignore
 
 Select and ignore patterns - you can ignore these.
+
+=item weight
+
+A number indicating the relative weight of the plugin, used to calculate the
+order the plugins will execute in. The lower the number the sooner the plugin
+will be executed.
+
+By default the weight will be C<50> for non validators (anything where
+C<is_validator> returns false) and C<60> for validators (anything where
+C<is_validator> returns true.)
+
+The order of plugin execution is determined first by the value of the C<weight>
+attribute, and then (if multiple plugins have the same weight>) by sorting by
+the name of module.
 
 =back
 

--- a/lib/Code/TidyAll/Plugin/DiffOnTidyError.pm
+++ b/lib/Code/TidyAll/Plugin/DiffOnTidyError.pm
@@ -56,9 +56,9 @@ __END__
 =head1 DESCRIPTION
 
 When running L<Code::TidyAll> in C<check_only> mode, for example via
-L<Test::Code::TidyAll>, this plugin adds a diff to the output when a file
-needs to be tidied. This plugin uses the F<diff> command, and will simply die
-if it cannot find one in your C<$PATH>.
+L<Test::Code::TidyAll>, this plugin adds a diff to the output when a file needs
+to be tidied. This plugin uses the F<diff> command, and will simply die if it
+cannot find one in your C<$PATH>.
 
 This is helpful if you're trying to figure out what a test is failing on.
 

--- a/t/lib/Code/TidyAll/Test/Plugin/AlwaysPhonetic.pm
+++ b/t/lib/Code/TidyAll/Test/Plugin/AlwaysPhonetic.pm
@@ -1,0 +1,38 @@
+package Code::TidyAll::Test::Plugin::AlwaysPhonetic;
+
+use Moo;
+extends 'Code::TidyAll::Plugin';
+
+my %phonetic = (
+    A => 'ALFA',
+    B => 'BRAVO',
+    C => 'CHARLIE',
+    D => 'DELTA',
+    E => 'ECHO',
+    F => 'FOXTROT',
+    G => 'GOLF',
+    H => 'HOTEL',
+    I => 'INDIA',
+    J => 'JULIETT',
+    K => 'KILO',
+    L => 'LIMA',
+    M => 'MIKE',
+    N => 'NOVEMBER',
+    O => 'OSCAR',
+    P => 'PAPA',
+    Q => 'QUEBEC',
+    R => 'ROMEO',
+    S => 'SIERRA',
+    T => 'TANGO',
+    U => 'UNIFORM',
+    V => 'VICTOR',
+    W => 'WHISKEY',
+    X => 'X-RAY',
+    Y => 'YANKEE',
+    Z => 'ZULU',
+);
+
+sub transform_source {
+    my ( $self, $source ) = @_;
+    return join '-', map { $phonetic{$_} } split //, $source;
+}

--- a/t/lib/Test/Code/TidyAll/Basic.pm
+++ b/t/lib/Test/Code/TidyAll/Basic.pm
@@ -139,9 +139,9 @@ sub test_plugin_order_and_atomicity : Tests {
             test_plugin("UpperText $_")  => { select => '**/*.txt' },
             test_plugin("CheckUpper $_") => { select => '**/*.txt' },
 
-            # note without the ordering here this would run first, and the
+            # note without the weight here this would run first, and the
             # letters in the photetic words themselves would be reversed
-            test_plugin("AlwaysPhonetic") => { select => '**/*.txt', ordering => 51 }
+            test_plugin("AlwaysPhonetic") => { select => '**/*.txt', weight => 51 }
             )
     } ( 1 .. 3 );
     my $output = capture_stdout {

--- a/t/lib/Test/Code/TidyAll/Basic.pm
+++ b/t/lib/Test/Code/TidyAll/Basic.pm
@@ -137,7 +137,11 @@ sub test_plugin_order_and_atomicity : Tests {
         (
             %ReverseFoo,
             test_plugin("UpperText $_")  => { select => '**/*.txt' },
-            test_plugin("CheckUpper $_") => { select => '**/*.txt' }
+            test_plugin("CheckUpper $_") => { select => '**/*.txt' },
+
+            # note without the ordering here this would run first, and the
+            # letters in the photetic words themselves would be reversed
+            test_plugin("AlwaysPhonetic") => { select => '**/*.txt', ordering => 51 }
             )
     } ( 1 .. 3 );
     my $output = capture_stdout {
@@ -145,7 +149,7 @@ sub test_plugin_order_and_atomicity : Tests {
             plugins => {@plugins},
             options => { verbose => 1 },
             source  => { "foo.txt" => "abc" },
-            dest    => { "foo.txt" => "CBA" },
+            dest    => { "foo.txt" => "CHARLIE-BRAVO-ALFA" },
             like_output =>
                 qr/.*ReverseFoo, .*UpperText 1, .*UpperText 2, .*UpperText 3, .*CheckUpper 1, .*CheckUpper 2, .*CheckUpper 3/
         );


### PR DESCRIPTION
Here's a first stab at a patch that allows manual ordering of plugins.

I originally worked this up so that the different stages of the plugin (preprocess, postprocess) etc could, if the plugin author / configuration file wanted, be ordered differently (each with their owner ordering attribute.)  But then I decided (a) that this was way too complex and (b) If you have total plugin ordering control then maybe we shouldn't be encouraging the use of these anyway.