### PR TITLE
Don't include files not tracked by git when looking for uncommitted files.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Don't include files not tracked by git when looking for uncommitted files.
+  (Olaf Alders)
+
 0.39     2016-02-13
 
 - Use "git status --porcelain -z" when trying to figure out what files are

--- a/lib/Code/TidyAll/Git/Util.pm
+++ b/lib/Code/TidyAll/Git/Util.pm
@@ -17,7 +17,7 @@ sub git_uncommitted_files {
     my $pushd = pushd( realpath($dir) );
     return
         map { rel2abs($_) }
-        _relevant_files_from_status( capturex(qw( git status --porcelain -z )) );
+        _relevant_files_from_status( capturex(qw( git status --porcelain -z -uno )) );
 }
 
 sub _relevant_files_from_status {


### PR DESCRIPTION
This can provide a big speed boost in situations where checking for untracked files can be quite slow.

```
vagrant@ct100-test:~/mm_website$ time git status --porcelain -z
?? .DS_Store?? doc/.DS_Store
real    0m1.628s
user    0m0.080s
sys     0m0.592s
vagrant@ct100-test:~/mm_website$ time git status --porcelain -z -uno

real    0m0.077s
user    0m0.015s
sys     0m0.061s
```