### PR TITLE
Fix error trying to use Plugin.pm as a base class.

### DIFF
--- a/lib/Code/TidyAll/Plugin.pm
+++ b/lib/Code/TidyAll/Plugin.pm
@@ -5,7 +5,7 @@ use File::Slurp::Tiny qw(read_file write_file);
 use File::Which qw( which );
 use IPC::Run3 qw( run3 );
 use Scalar::Util qw(weaken);
-use Text::Diff 1.44 qw( diff );
+use Text::Diff v1.44 qw( diff );
 
 use Moo;
 


### PR DESCRIPTION
This fixes the issues mentioned in #53. With this change everything is fine for me on my local Perl 5.18.2 (OS X).