### PR TITLE
Preserve file mode (permissions) on tidy.

### DIFF
--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -350,7 +350,7 @@ sub process_file {
 
         # write new contents out to disk
         $contents = $result->new_contents;
-        path( $full_path . $self->output_suffix )->spew($contents);
+        path( $full_path . $self->output_suffix )->append( { truncate => 1 }, $contents );
 
         # change the in memory contents of the cache (but don't update yet)
         $cache_model->file_contents($contents) unless $self->output_suffix;

--- a/t/lib/Test/Code/TidyAll/Basic.pm
+++ b/t/lib/Test/Code/TidyAll/Basic.pm
@@ -78,6 +78,20 @@ sub test_basic : Tests {
     );
 }
 
+sub test_filemode : Tests {
+    my $self     = shift;
+    my $root_dir = $self->create_dir( { "foo.txt" => "abc" } );
+    my $file     = $root_dir->child('foo.txt');
+    $file->chmod('0755');
+    my $ct = Code::TidyAll->new(
+        plugins  => { test_plugin('UpperText') => { select => '**/foo*' } },
+        root_dir => $root_dir,
+    );
+    $ct->process_paths($file);
+    is( $file->slurp,      "ABC" );
+    is( $file->stat->mode, 0100755 );
+}
+
 sub test_multiple_plugin_instances : Tests {
     my $self = shift;
     $self->tidy(


### PR DESCRIPTION
Fix for issue #68.

This changes the method of writing out the tidied file from ->spew() to
->append({truncate => 1}). spew() copies the new file into place, which
ends up resetting the file mode based on the current umask. Using append()
instead preserves the file permissions and ownership, without us having
to keep track of the mode and resetting it after writing the file.

(This is describe in the Path::Tiny docs, here: https://metacpan.org/pod/Path::Tiny#spew-spew_raw-spew_utf8)
