### PR TITLE
Fix broken POD. Must have a space.

### DIFF
--- a/lib/Test/Code/TidyAll.pm
+++ b/lib/Test/Code/TidyAll.pm
@@ -104,7 +104,7 @@ By default, we look for the config file C<tidyall.ini> or C<.tidyallrc> in the
 current directory and parent directories, which is generally the right place if
 you are running L<prove>.
 
-When invoking L<Code::TidyAll>, we pass C<<mode => 'test'>> by default; see
+When invoking L<Code::TidyAll>, we pass C<< mode => 'test' >> by default; see
 L<modes|tidyall/MODES>.
 
 =head1 EXPORTS


### PR DESCRIPTION
There are double angle brackets which require spaces. See https://github.com/metacpan/metacpan-web/issues/1841 - thanks to @haarg .