### PR TITLE
chdir to $ROOT before running commands

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- chdir to $ROOT before running commands. Olaf Alders. GH #85
+
 0.68     2017-09-29
 
 - Fixed heisenbug that could cause displaying constructor params (in verbose

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -12,6 +12,7 @@ use Data::Dumper;
 use Date::Format;
 use Digest::SHA qw(sha1_hex);
 use File::Find qw(find);
+use File::pushd qw( pushd );
 use File::Zglob qw(zglob);
 use List::SomeUtils qw(uniq);
 use Module::Runtime qw( use_module );
@@ -472,6 +473,7 @@ sub process_paths {
             || $_->absolute
     } map { path($_) } @paths;
 
+    my $dir = pushd( $self->root_dir );
     if ( $self->jobs > 1 && @paths > 1 ) {
         return $self->_process_parallel(@paths);
     }

--- a/t/Basic.t
+++ b/t/Basic.t
@@ -3,11 +3,10 @@
 use strict;
 use warnings;
 
+use lib::relative 'lib';
+
 use Config;
 use File::Spec ();
-use FindBin    ();
-
-use lib "$FindBin::Bin/lib";
 
 $ENV{PERL5LIB} = join $Config{path_sep},
     File::Spec->rel2abs('./t/lib'), split $Config{path_sep},

--- a/t/Basic.t
+++ b/t/Basic.t
@@ -1,4 +1,17 @@
 #!/usr/bin/perl
-use lib 't/lib';
+
+use strict;
+use warnings;
+
+use Config;
+use File::Spec ();
+use FindBin    ();
+
+use lib "$FindBin::Bin/lib";
+
+$ENV{PERL5LIB} = join $Config{path_sep},
+    File::Spec->rel2abs('./t/lib'), split $Config{path_sep},
+    ( $ENV{PERL5LIB} || q{} );
+
 use TestFor::Code::TidyAll::Basic;
 TestFor::Code::TidyAll::Basic->runtests;


### PR DESCRIPTION
This fixes Perl::Critic spell checks, which look for a stopwords file
that might be a file relative to the root directory.

Fixes #85 