### PR TITLE
Fix linked plugin class name

### DIFF
--- a/bin/tidyall
+++ b/bin/tidyall
@@ -248,7 +248,7 @@ distribution comes with plugins for:
 
 Perl: L<perlcritic|Code::TidyAll::Plugin::PerlCritic>,
 L<perltidy|Code::TidyAll::Plugin::PerlTidy>,
-L<perltidy-sweet|Code::TidyAll::Plugin::PerlTidy::Sweetened>
+L<perltidy-sweet|Code::TidyAll::Plugin::PerlTidySweet>
 
 =item *
 


### PR DESCRIPTION
`s{Plugin::PerlTidy::Sweetened}{Plugin::PerlTidySweet}`

( Also: this repo shows up as type 'PHP' in my GitHub dashboard :-/ )