### PR TITLE
Try to fix the tests on Windows.

### DIFF
--- a/t/lib/TestFor/Code/TidyAll/Plugin/GenericTransformer.pm
+++ b/t/lib/TestFor/Code/TidyAll/Plugin/GenericTransformer.pm
@@ -2,12 +2,19 @@ package TestFor::Code::TidyAll::Plugin::GenericTransformer;
 
 use Test::Class::Most parent => 'TestFor::Code::TidyAll::Plugin';
 
+sub _mswin_compat {
+    my $cmd = shift;
+
+    # Get the tests to pass on windows due to shellwords()
+    $cmd =~ s#\\#/#g;
+    return $cmd;
+}
+
 sub test_main : Tests {
     my $self = shift;
 
-    my $trans
-        = $^X
-        . q{ -MPath::Tiny=path -e 'my $content = path(shift)->slurp; $content =~ s/forbidden/safe/i; print $content'};
+    my $trans = _mswin_compat( $^X . ' ' . 't/lib/progs/trans1.pl' );
+
     $self->tidyall(
         source    => 'this text is unchanged',
         expect_ok => 1,
@@ -29,7 +36,7 @@ sub test_main : Tests {
         expect_error => qr/exited with 3/,
         desc         => 'exit code of 3 is an exception',
         conf         => {
-            cmd           => qq{$^X -e 'exit 3'},
+            cmd           => _mswin_compat(qq{$^X -e "exit 3"}),
             ok_exit_codes => [ 0, 1, 2 ],
         },
     );

--- a/t/lib/TestFor/Code/TidyAll/Plugin/GenericValidator.pm
+++ b/t/lib/TestFor/Code/TidyAll/Plugin/GenericValidator.pm
@@ -2,10 +2,19 @@ package TestFor::Code::TidyAll::Plugin::GenericValidator;
 
 use Test::Class::Most parent => 'TestFor::Code::TidyAll::Plugin';
 
+sub _mswin_compat {
+    my $cmd = shift;
+
+    # Get the tests to pass on windows due to shellwords()
+    $cmd =~ s#\\#/#g;
+    return $cmd;
+}
+
 sub test_main : Tests {
     my $self = shift;
 
-    my $val = qq{$^X -MPath::Tiny=path -e 'exit 1 if path(shift)->slurp =~ /forbidden/i'};
+    my $val = _mswin_compat(qq{$^X t/lib/progs/validator1.pl});
+
     $self->tidyall(
         source    => 'this text is ok',
         expect_ok => 1,
@@ -27,7 +36,7 @@ sub test_main : Tests {
         expect_ok => 1,
         desc      => 'exit code of 2 is ok',
         conf      => {
-            cmd           => qq{$^X -e 'exit 2'},
+            cmd           => _mswin_compat(qq{$^X -e "exit 2"}),
             ok_exit_codes => [ 0, 1, 2 ],
         },
     );
@@ -36,7 +45,7 @@ sub test_main : Tests {
         expect_error => qr/exited with 3/,
         desc         => 'exit code of 3 is an exception',
         conf         => {
-            cmd           => qq{$^X -e 'exit 3'},
+            cmd           => _mswin_compat(qq{$^X -e "exit 3"}),
             ok_exit_codes => [ 0, 1, 2 ],
         },
     );

--- a/t/lib/progs/trans1.pl
+++ b/t/lib/progs/trans1.pl
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Path::Tiny qw/ path /;
+
+my $content = path(shift)->slurp;
+$content =~ s/forbidden/safe/i;
+print $content;

--- a/t/lib/progs/validator1.pl
+++ b/t/lib/progs/validator1.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Path::Tiny qw/ path /;
+exit 1 if path(shift)->slurp =~ /forbidden/i;


### PR DESCRIPTION
See https://github.com/houseabsolute/perl-code-tidyall/issues/90 . The
tests probably failed due to improper quoting. Extracted the -e one
liners into their own files.

Let's see if appveyor passes.