### PR TITLE
Fix warning when using "shebang" with empty files

### DIFF
--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -791,7 +791,8 @@ sub _matched_by_plugin {
 
     my %is_ignored = map { $_ => 1 }
         $self->_zglob( [ @{ $self->ignores || [] }, @{ $plugin->ignores || [] } ] );
-    my @matched = grep { !$is_ignored{$_} } grep { -f && !-l } $self->_zglob( $plugin->selects );
+    my @matched
+        = grep { !$is_ignored{$_} } grep { -f && -s && !-l } $self->_zglob( $plugin->selects );
 
     my $shebang = $plugin->shebang
         or return @matched;

--- a/t/lib/TestFor/Code/TidyAll/Basic.pm
+++ b/t/lib/TestFor/Code/TidyAll/Basic.pm
@@ -11,6 +11,7 @@ use Path::Tiny qw(cwd path);
 
 use Test::Class::Most parent => 'TestHelper::Test::Class';
 use Test::Fatal;
+use Test::Warnings;
 
 sub test_plugin {"+TestHelper::Plugin::$_[0]"}
 my %UpperText
@@ -345,6 +346,7 @@ sub test_shebang : Tests {
         'b/bar'    => '#!/usr/bin/perl5',
         'b/baz'    => '#!perl -w',
         'b/bar.pm' => 'package b::bar;',
+        'empty'    => q{},
     );
     my $root_dir = $self->create_dir( \%files );
     my $ct       = Code::TidyAll->new(


### PR DESCRIPTION
Previously, tidyall would warn on empty files when using the `shebang` option:

Use of uninitialized value in pattern match (m//) at Code/TidyAll.pm line 804.