### PR TITLE
Fix Git tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- Ignore local Git configuration files, which may break the Git tests.
+
 - Run the Git tests with LC_ALL set to C. GH #109.
 
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Run the Git tests with LC_ALL set to C. GH #109.
+
+
 0.81     2022-02-16
 
 - The PerlTidy plugin will now always append the `--encode-output-strings`

--- a/t/Git.t
+++ b/t/Git.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
 use lib::relative 'lib';
 use TestFor::Code::TidyAll::Git;
+$ENV{LC_ALL} = 'C';
 TestFor::Code::TidyAll::Git->runtests;

--- a/t/lib/TestFor/Code/TidyAll/Git.pm
+++ b/t/lib/TestFor/Code/TidyAll/Git.pm
@@ -5,6 +5,7 @@ use Code::TidyAll::Git::Util qw(git_files_to_commit git_modified_files);
 use Code::TidyAll::Util qw(tempdir_simple);
 use Code::TidyAll;
 use File::pushd qw(pushd);
+use File::Spec;
 use FindBin qw( $Bin );
 use IPC::System::Simple qw(capturex runx);
 use Path::Tiny qw(path);
@@ -17,6 +18,10 @@ my ( $precommit_hook_template, $prereceive_hook_template, $tidyall_ini_template 
 
 $ENV{GIT_AUTHOR_NAME}  = $ENV{GIT_COMMITTER_NAME}  = 'G. Author';
 $ENV{GIT_AUTHOR_EMAIL} = $ENV{GIT_COMMITTER_EMAIL} = 'git-author@example.com';
+
+# Ignore local configuration files, which may change the default branch from
+# "master" to "main".
+$ENV{GIT_CONFIG_GLOBAL} = $ENV{GIT_CONFIG_SYSTEM} = File::Spec->devnull;
 
 BEGIN {
     if (IS_WIN32) {


### PR DESCRIPTION
This pull request makes the Git tests more reliable. The first commit fixes #109 by setting LC_ALL to "C".

The second commit sets the environment variables GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM to "/dev/null". Local configuration files may change the default branch from "master" to "main", which causes the Git tests to fail. Alternatively, "-b master" could be passed to "git init". But the option "-b" was only added to Git 2.28 in 2020.