### PR TITLE
Add github annotations output for check only mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@
 
 - Fixed test failures on msys. Implemented by Paulo Custodio. GH #116.
 
+- When running under GitHub Actions in --check-only mode, linting failures
+  will now emit GitHub annotations
+  (https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-creating-an-annotation-for-an-error). Implemented
+  by Pavel Dostál. GH #120.
+
 
 0.82     2022-04-15
 

--- a/lib/Code/TidyAll.pm
+++ b/lib/Code/TidyAll.pm
@@ -673,6 +673,12 @@ sub process_source {
     my $was_tidied = !$error && ( $new_contents ne $orig_contents );
     if ( $was_tidied && $self->check_only ) {
         $error = '*** needs tidying';
+
+        # Github annotations parsable output to highlight code in pull requests
+        if ($ENV{GITHUB_ACTIONS}) {
+            $error .= "\n::error file=${path}::File ${path} needs tidying"
+        }
+
         foreach my $diff (@diffs) {
             $error .= "\n\n";
             $error .= "$diff->[0] made the following change:\n$diff->[1]";

--- a/t/lib/TestFor/Code/TidyAll/DiffOnTidyError.pm
+++ b/t/lib/TestFor/Code/TidyAll/DiffOnTidyError.pm
@@ -20,6 +20,20 @@ sub test_diff_on_tidy_error : Tests {
         errors      => qr/needs tidying/,
         like_output => qr/UpperText made the following change:\n.+abc\n.+ABC/s,
     );
+
+    $ENV{GITHUB_ACTIONS} = 'true';
+    $self->tidy(
+        plugins => {
+            '+TestHelper::Plugin::UpperText' => {
+                diff_on_tidy_error => 1,
+                select             => '**/*.txt',
+            },
+        },
+        source      => { 'foo.txt'  => 'abc' },
+        options     => { check_only => 1 },
+        desc        => 'diff on tidy error running in github actions',
+        errors      => qr/::error file=foo\.txt::File foo\.txt needs tidying/,
+    );
 }
 
 1;


### PR DESCRIPTION
Hello,

I'd like to add Github Actions parsable annotations for the check only mode.
This would highlight files where tidying is needed in the pull requests.

Here is an example of how the annotation looks:
![image](https://user-images.githubusercontent.com/1254493/198281872-366fb305-8d33-4f74-b683-faee96c5047a.png)
