### PR TITLE
specifically override default branch name

### DIFF
--- a/t/lib/TestFor/Code/TidyAll/Git.pm
+++ b/t/lib/TestFor/Code/TidyAll/Git.pm
@@ -14,13 +14,16 @@ use Try::Tiny;
 
 use constant IS_WIN32 => $^O eq 'MSWin32';
 
+use constant GIT => qw(git -c init.defaultBranch=master);
+
 my ( $precommit_hook_template, $prereceive_hook_template, $tidyall_ini_template );
 
 $ENV{GIT_AUTHOR_NAME}  = $ENV{GIT_COMMITTER_NAME}  = 'G. Author';
 $ENV{GIT_AUTHOR_EMAIL} = $ENV{GIT_COMMITTER_EMAIL} = 'git-author@example.com';
 
 # Ignore local configuration files, which may change the default branch from
-# "master" to "main".
+# "master" to "main". Not all versions of GIT support GIT_CONFIG_GLOBAL, however,
+# so further settings need to be done on the command line.
 $ENV{GIT_CONFIG_GLOBAL} = $ENV{GIT_CONFIG_SYSTEM} = File::Spec->devnull;
 
 BEGIN {
@@ -42,7 +45,7 @@ sub test_git : Tests {
         $work_dir->child('foo.txt')->spew_raw("abc\n");
         cmp_deeply( [ git_files_to_commit($work_dir) ], [], 'no files to commit' );
 
-        runx(qw( git add foo.txt ));
+        runx( GIT, qw( add foo.txt ));
         cmp_deeply(
             [ map { $_->stringify } git_files_to_commit($work_dir) ],
             [ $work_dir->child('foo.txt')->stringify ], 'one file to commit'
@@ -50,7 +53,7 @@ sub test_git : Tests {
     };
 
     subtest 'attempt to commit untidy file', sub {
-        my $output = capture_stderr { system(qw( git commit -q -m changed -a )) };
+        my $output = capture_stderr { system( GIT, qw( commit -q -m changed -a )) };
         like( $output, qr/1 file did not pass tidyall check/, '1 file did not pass tidyall check' );
         like( $output, qr/needs tidying/,                     'needs tidying' );
         $self->_assert_something_to_commit($work_dir);
@@ -58,15 +61,15 @@ sub test_git : Tests {
 
     subtest 'successfully commit tidied file', sub {
         $work_dir->child('foo.txt')->spew_raw("ABC\n");
-        my $output = capture_stderr { runx(qw( git commit -q -m changed -a )) };
+        my $output = capture_stderr { runx( GIT, qw( commit -q -m changed -a )) };
         like( $output, qr/\[checked\] foo\.txt/, 'checked foo.txt' );
         $self->_assert_nothing_to_commit($work_dir);
     };
 
     subtest 'add another file which is tidied', sub {
         $work_dir->child('bar.txt')->spew_raw('ABC');
-        runx(qw( git add bar.txt ));
-        runx(qw( git commit -q -m bar.txt ));
+        runx( GIT, qw( add bar.txt ));
+        runx( GIT, qw( commit -q -m bar.txt ));
 
         $work_dir->child('bar.txt')->spew('def');
         cmp_deeply( [ git_files_to_commit($work_dir) ], [], 'no files to commit' );
@@ -82,8 +85,8 @@ sub test_git : Tests {
         $shared_dir = $temp_dir->child('shared');
         $clone_dir  = $temp_dir->child('clone');
 
-        runx( qw( git clone -q --bare ), map { _quote_for_win32($_) } $work_dir,   $shared_dir );
-        runx( qw( git clone -q ),        map { _quote_for_win32($_) } $shared_dir, $clone_dir );
+        runx( GIT, qw( clone -q --bare ), map { _quote_for_win32($_) } $work_dir,   $shared_dir );
+        runx( GIT, qw( clone -q ),        map { _quote_for_win32($_) } $shared_dir, $clone_dir );
         chdir($clone_dir);
         $self->_assert_nothing_to_commit($work_dir);
     };
@@ -95,13 +98,13 @@ sub test_git : Tests {
 
     subtest 'untidy file and attempt to commit it via commit -a', sub {
         $clone_dir->child('foo.txt')->spew_raw("def\n");
-        runx(qw( git commit -q -m changed -a ));
+        runx( GIT, qw( commit -q -m changed -a ));
         $self->_assert_nothing_to_commit($work_dir);
         $self->_assert_branch_is_ahead_of_origin;
     };
 
     subtest 'cannot push untidy file', sub {
-        my $output = capture_stderr { system(qw( git push )) };
+        my $output = capture_stderr { system( GIT, qw( push )) };
         like( $output, qr/master -> master/,                  'master -> master' );
         like( $output, qr/1 file did not pass tidyall check/, '1 file did not pass tidyall check' );
         like( $output, qr/needs tidying/,                     'needs tidying' );
@@ -110,30 +113,30 @@ sub test_git : Tests {
 
     subtest 'can push tidied file', sub {
         $clone_dir->child('foo.txt')->spew_raw("DEF\n");
-        capture_stderr { runx(qw( git commit -q -m changed -a )) };
+        capture_stderr { runx( GIT, qw( commit -q -m changed -a )) };
         $self->_assert_nothing_to_commit($work_dir);
-        my $output = capture_stderr { system(qw( git push )) };
+        my $output = capture_stderr { system( GIT, qw( push )) };
         like( $output, qr/master -> master/, 'push succeeded' );
         $self->_assert_nothing_to_push;
     };
 
     subtest 'untidy file and commit it', sub {
         $clone_dir->child('foo.txt')->spew_raw("def\n");
-        runx(qw( git commit -q -m changed -a ));
+        runx( GIT, qw( commit -q -m changed -a ));
         $self->_assert_nothing_to_commit($work_dir);
         $self->_assert_branch_is_ahead_of_origin;
     };
 
     subtest 'cannot push when file is untidy', sub {
         $self->_assert_branch_is_ahead_of_origin;
-        my $output = capture_stderr { system(qw( git push )) };
+        my $output = capture_stderr { system(GIT, qw( push )) };
         like( $output, qr/needs tidying/, 'needs tidying' );
         $self->_assert_branch_is_ahead_of_origin;
     };
 
     subtest 'cannot push when file is untidy (2nd try)', sub {
         $self->_assert_branch_is_ahead_of_origin;
-        my $output = capture_stderr { system(qw( git push )) };
+        my $output = capture_stderr { system(GIT, qw( push )) };
         like( $output, qr/needs tidying/,               'needs tidying' );
         like( $output, qr/Identical push seen 2 times/, 'Identical push seen 2 times' );
         $self->_assert_branch_is_ahead_of_origin;
@@ -153,15 +156,15 @@ sub test_copied_status : Tests {
     # "copied" status.
     $foo_file->spew_raw( "ABC\n" x 500 );
 
-    runx(qw( git add foo.txt ));
-    runx(qw( git commit -m foo ));
+    runx( GIT, qw( add foo.txt ));
+    runx( GIT, qw( commit -m foo ));
 
     my $bar_file = $work_dir->child('bar.txt');
     $bar_file->spew_raw( "ABC\n" x 500 );
     $foo_file->spew_raw(q{});
 
-    runx(qw( git add foo.txt bar.txt ));
-    my $output = capture_stderr { runx(qw( git commit -m bar )) };
+    runx( GIT, qw( add foo.txt bar.txt ));
+    my $output = capture_stderr { runx( GIT, qw( commit -m bar )) };
     unlike(
         $output,
         qr/uninitialized value/i,
@@ -184,8 +187,8 @@ sub test_precommit_stash_issues : Tests {
 
     subtest 'commit two tidy files', sub {
         $self->_assert_something_to_commit($work_dir);
-        runx(qw( git add foo.txt bar.txt ));
-        my $output = capture_stderr( sub { runx(qw( git commit -q -m two )) } );
+        runx( GIT, qw( add foo.txt bar.txt ));
+        my $output = capture_stderr( sub { runx( GIT, qw( commit -q -m two )) } );
         like( $output, qr/\Q[checked] foo.txt/, 'tidyall checked foo.txt' );
         like( $output, qr/\Q[checked] bar.txt/, 'tidyall checked bar.txt' );
         $self->_assert_nothing_to_commit($work_dir);
@@ -196,7 +199,7 @@ sub test_precommit_stash_issues : Tests {
 
     subtest 'cannot commit untidy files', sub {
         $self->_assert_something_to_commit($work_dir);
-        my $output = capture_stderr( sub { system(qw( git commit -q -a -m untidy )) } );
+        my $output = capture_stderr( sub { system(GIT, qw( commit -q -a -m untidy )) } );
         like(
             $output,
             qr/2 files did not pass tidyall check/,
@@ -211,8 +214,8 @@ sub test_precommit_stash_issues : Tests {
     $baz_file->spew_raw("ABC\n");
 
     subtest 'commit one valid file and working directory is left intact', sub {
-        runx(qw( git add foo.txt ));
-        my ( $stdout, $stderr ) = capture( sub { system(qw( git commit -q -m foo )) } );
+        runx( GIT, qw( add foo.txt ));
+        my ( $stdout, $stderr ) = capture( sub { system(GIT, qw( commit -q -m foo )) } );
         like(
             $stdout,
             qr/modified:\s+bar\.txt/,
@@ -225,7 +228,7 @@ sub test_precommit_stash_issues : Tests {
             'bar.txt is still modified in working directory'
         );
 
-        my $status = capturex(qw( git status --porcelain -unormal ));
+        my $status = capturex(GIT, qw( status --porcelain -unormal ));
         like(
             $status,
             qr/^\?\?\s+baz.txt/m,
@@ -235,8 +238,8 @@ sub test_precommit_stash_issues : Tests {
 
     $foo_file->spew_raw("abc\n");
     subtest 'commit one invalid file and working directory is left intact', sub {
-        runx(qw( git add foo.txt ));
-        my ( undef, $stderr ) = capture( sub { system(qw( git commit -q -m foo )) } );
+        runx( GIT, qw( add foo.txt ));
+        my ( undef, $stderr ) = capture( sub { system(GIT, qw( commit -q -m foo )) } );
         like(
             $stderr,
             qr/needs tidying/,
@@ -253,7 +256,7 @@ sub test_precommit_stash_issues : Tests {
             'bar.txt is still modified in working directory'
         );
 
-        my $status = capturex(qw( git status --porcelain -unormal ));
+        my $status = capturex(GIT, qw( status --porcelain -unormal ));
         like(
             $status,
             qr/^\?\?\s+baz.txt/m,
@@ -261,23 +264,23 @@ sub test_precommit_stash_issues : Tests {
         );
     };
 
-    runx(qw( git clean -q -dxf ));
+    runx( GIT, qw( clean -q -dxf ));
 
     # We need to add to the stash so we can make sure that it's not popped
     # incorrectly later.
     $foo_file->spew_raw("abC\n");
-    runx(qw( git stash -q ));
+    runx( GIT, qw( stash -q ));
 
     subtest 'precommit hook does not pop when it did not stash', sub {
         $foo_file->spew_raw("ABCD\n");
-        runx(qw( git commit -q -a -m changed ));
+        runx( GIT, qw( commit -q -a -m changed ));
 
         # The bug we're fixing is that this commit would always pop the stash,
         # even though the Precommit hook's call to "git stash" hadn't _added_
         # to the stash. This meant we'd end up potentially popping some random
         # thing off the stash, making a huge mess.
         my $e;
-        try { runx(qw( git commit -q --amend -m amended )) }
+        try { runx( GIT, qw( commit -q --amend -m amended )) }
         catch { $e = $_ };
         is(
             $e,
@@ -298,23 +301,23 @@ sub test_precommit_no_stash_merge : Tests {
 
     $work_dir->child('file1.txt')->spew("A\nB\n");
     $work_dir->child('file2.txt')->spew("A\nB\n");
-    runx(qw( git add file1.txt file2.txt ));
-    runx( qw( git commit -m ), 'Add files in master' );
+    runx( GIT, qw( add file1.txt file2.txt ));
+    runx( GIT, qw( commit -m ), 'Add files in master' );
 
     $work_dir->child('file1.txt')->append("C\n");
     $work_dir->child('file2.txt')->append("C\n");
-    runx( qw( git commit -a -m ), 'Update files in master' );
+    runx( GIT, qw( commit -a -m ), 'Update files in master' );
 
-    runx(qw( git checkout -b my-branch ));
-    runx(qw( git reset --hard HEAD~1 ));
+    runx( GIT, qw( checkout -b my-branch ));
+    runx( GIT, qw( reset --hard HEAD~1 ));
 
     $work_dir->child('file1.txt')->append("D\n");
     $work_dir->child('file2.txt')->append("C\n");
-    runx(qw( git add file1.txt file2.txt ));
-    runx( qw( git commit  -m ), 'Update files in my-branch' );
+    runx( GIT, qw( add file1.txt file2.txt ));
+    runx( GIT, qw( commit  -m ), 'Update files in my-branch' );
 
     # This will exit with 1 because of the conflict.
-    runx( [1], qw( git merge master ) );
+    runx( [1], GIT, qw( merge master ) );
 
     like(
         $work_dir->child(qw( .git MERGE_MSG ))->slurp,
@@ -326,9 +329,9 @@ sub test_precommit_no_stash_merge : Tests {
 
     # We need a change that will be stashed to trigger the bug.
     $work_dir->child('file2.txt')->append("E\n");
-    runx(qw( git add file1.txt ));
-    runx( qw( git commit -m ), 'Add file1.txt in my-branch for real' );
-    my $output = capturex(qw( git log -n 1 ));
+    runx( GIT, qw( add file1.txt ));
+    runx( GIT, qw( commit -m ), 'Add file1.txt in my-branch for real' );
+    my $output = capturex(GIT, qw( log -n 1 ));
     like( $output, qr/Merge: [0-9a-f]+ [0-9a-f]+/, 'last commit was a merge commit' );
 }
 
@@ -339,7 +342,7 @@ sub _make_working_dir_and_repo {
     my $work_dir  = $temp_dir->child('work');
     my $hooks_dir = $work_dir->child(qw( .git hooks ));
 
-    runx( qw( git init -q ), _quote_for_win32($work_dir) );
+    runx( GIT, qw( init -q ), _quote_for_win32($work_dir) );
 
     # This dir doesn't exist unless there's a git dir template that includes
     # the hooks subdir.
@@ -350,8 +353,8 @@ sub _make_working_dir_and_repo {
 
     $work_dir->child('tidyall.ini')->spew($tidyall_ini_template);
     $work_dir->child('.gitignore')->spew('.tidyall.d');
-    runx(qw( git add tidyall.ini .gitignore ));
-    runx(qw( git commit -q -m added tidyall.ini .gitignore ));
+    runx( GIT, qw( add tidyall.ini .gitignore ));
+    runx( GIT, qw( commit -q -m added tidyall.ini .gitignore ));
 
     my $precommit_hook_file = $hooks_dir->child('pre-commit');
     my $precommit_hook      = sprintf( $precommit_hook_template, $self->_lib_dirs );
@@ -394,14 +397,14 @@ sub _assert_something_to_commit {
 
 sub _assert_nothing_to_push {
     unlike(
-        capturex( 'git', 'status' ),
+        capturex( GIT, 'status' ),
         qr/Your branch is ahead/,
         'branch is up to date with origin'
     );
 }
 
 sub _assert_branch_is_ahead_of_origin {
-    like( capturex( 'git', 'status' ), qr/Your branch is ahead/, 'branch is ahead of origin' );
+    like( capturex( GIT, 'status' ), qr/Your branch is ahead/, 'branch is ahead of origin' );
 }
 
 $precommit_hook_template = '#!' . $^X . "\n" . <<'EOF';


### PR DESCRIPTION
Setting GIT_CONFIG_GLOBAL to prevent loading of ~/.gitconfig isn't suppoted by all versions of git; on those one may still get test failures if the user has specified a init.defaultBranch configuration value which is different from the test expects.

Explicitly pass it on the 'git' command line to ensure that it is indepndent of the user's configuration.

use the default branch name of 'default-branch' to make it obvious.