### PR TITLE
make option parsing case sensitive

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Fixed a bug that made it impossible to specify both `-i` and `-I` with
+  `tidyall. GH #125. PR #126. Fixed by @mauke.
+
+
 0.83     2022-11-19
 
 - Fixed test failures on msys. Implemented by Paulo Custodio. GH #116.

--- a/bin/tidyall
+++ b/bin/tidyall
@@ -72,6 +72,7 @@ my (
 
 my @conf_names = Code::TidyAll->default_conf_names;
 
+Getopt::Long::Configure('no_ignore_case');
 GetOptions(
     'a|all'           => \$all_files,
     'i|ignore=s@'     => \$params{ignore},


### PR DESCRIPTION
This allows `-i` and `-I` to be used without conflicting with each other.
Fixes #125.