### PR TITLE
Fix for changes in Path::Tiny 0.147

### DIFF
--- a/t/lib/TestFor/Code/TidyAll/Git.pm
+++ b/t/lib/TestFor/Code/TidyAll/Git.pm
@@ -343,7 +343,7 @@ sub _make_working_dir_and_repo {
 
     # This dir doesn't exist unless there's a git dir template that includes
     # the hooks subdir.
-    $hooks_dir->mkpath( 0, 0755 );
+    $hooks_dir->mkpath( { verbose => 0, mode => 0755 } );
     ok( -d $_, "$_ exists" ) for ( $work_dir, $hooks_dir );
 
     my $pushd = pushd($work_dir);


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Code-TidyAll.
We thought you might be interested in it too.

    Description: Fix for changes in Path::Tiny 0.147
     mkpath needs nothing or a hashref as an argument,
     cf. https://github.com/dagolden/Path-Tiny/commit/07dc0eef61ecd748821c3fdd135f72419b257fa3
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1101853
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-04-03
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcode-tidyall-perl/raw/master/debian/patches/path_tiny_0.1.47.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
